### PR TITLE
Set a default for first name/last name if the field is empty.

### DIFF
--- a/comms.php
+++ b/comms.php
@@ -97,9 +97,11 @@ class turnitintool_commclass {
             $iUln = turnitintool_pseudolastname( $iUem );
             $iUem = turnitintool_pseudoemail( $iUem );
         }
+        
+        // Set a default for first and last name in the event they are empty.
+        $this->ufn = (empty($iUfn)) ? "N/A" : $iUfn;
+        $this->uln = (empty($iUln)) ? "N/A" : $iUln;
 
-        $this->ufn=$iUfn;
-        $this->uln=$iUln;
         $this->uem=$iUem;
         $this->utp=$iUtp;
         $this->loaderbar =& $iLoaderBar;


### PR DESCRIPTION
Similar to the patch from V2 of the plugin: https://github.com/turnitin/moodle-mod_turnitintooltwo/pull/63

But I will be submitting a patch to V2 to change the defaults to N/A as well.