### PR TITLE
Remove commented code that was annoying me

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -284,5 +284,3 @@ class mod_turnitintool_mod_form extends moodleform_mod {
 
     }
 }
-
-/* ?> */


### PR DESCRIPTION
PHP end tag was still in file but commented out. Moodle best practice is to omit `?>` closing tag entirely.