### PR TITLE
Moodle 3.2 changes required.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -7297,11 +7297,13 @@ function turnitintool_header($cm,$course,$url,$title='', $heading='', $navigatio
             $PAGE->navbar->add(get_string('modulenameplural', 'turnitintool'), new moodle_url($CFG->wwwroot.'/mod/turnitintool/index.php', array('id'=>$course->id)));
             $PAGE->navbar->add($title);
 
-            // Settings required for the edit cog to appear in boost theme.
+            // Set the context to ensure the edit assignment links appear in non-Boost themes.
+            $PAGE->set_cm($cm);
+            $PAGE->set_context(context_module::instance($cm->id));
+
+            // Setting required for the edit cog to appear in boost theme.
             if ($CFG->theme == "boost") {
-                $PAGE->set_cm($cm);
                 $PAGE->force_settings_menu(true);
-                $PAGE->set_context(context_module::instance($cm->id));
             }
         }
 

--- a/lib.php
+++ b/lib.php
@@ -7296,6 +7296,13 @@ function turnitintool_header($cm,$course,$url,$title='', $heading='', $navigatio
             $PAGE->navbar->add($course->shortname, new moodle_url($CFG->wwwroot.'/course/view.php', array('id'=>$course->id)));
             $PAGE->navbar->add(get_string('modulenameplural', 'turnitintool'), new moodle_url($CFG->wwwroot.'/mod/turnitintool/index.php', array('id'=>$course->id)));
             $PAGE->navbar->add($title);
+
+            // Settings required for the edit cog to appear in boost theme.
+            if ($CFG->theme == "boost") {
+                $PAGE->set_cm($cm);
+                $PAGE->force_settings_menu(true);
+                $PAGE->set_context(context_module::instance($cm->id));
+            }
         }
 
         $url_array = explode( '/mod/turnitintool', $url, 2 );
@@ -7303,13 +7310,6 @@ function turnitintool_header($cm,$course,$url,$title='', $heading='', $navigatio
         $PAGE->set_url($url);
         $PAGE->set_title($title);
         $PAGE->set_heading($heading);
-
-        // Settings required for the edit cog to appear in boost theme.
-        if ($CFG->theme == "boost") {
-            $PAGE->set_cm($cm);
-            $PAGE->force_settings_menu(true);
-            $PAGE->set_context(context_module::instance($cm->id));
-        }
 
         if ($return) {
             return $OUTPUT->header();

--- a/styles.css
+++ b/styles.css
@@ -155,12 +155,7 @@ button {
 #turnitintool_style .submissionTable .error {
     border: 1px solid red;
 }
-#turnitintool_style .submissionText {
-    height: 140px;
-    width: 80%;
-    font-family: inherit;
-    font-size: 85%;
-}
+
 #turnitintool_style .centertext {
     text-align: center;
 }
@@ -585,4 +580,10 @@ button {
 
 .form-group.boldlabel .col-md-3 {
     font-weight: bold;
+}
+
+#turnitintool_style #id_submissiontext,
+#turnitintool_style #submitbox .submissionText {
+    width: 600px;
+    height: 300px;
 }

--- a/styles.css
+++ b/styles.css
@@ -469,6 +469,14 @@ button {
     position: relative;
     top: 2px;
 }
+
+
+#turnitintool_style #unlink_wrapper .dt_page {
+    margin-bottom: 20px;
+}
+
+
+
 #turnitintool_style .dataTables_info {
     text-align: center;
 }


### PR DESCRIPTION
This pull request fixes a few issues with Moodle 3.2 and our development branch.

- Unlink/relink page now loads correctly and next/previous links do not overlap the filter box.
- The sizing on the text upload textarea has been defined as it was the default small size following changes for Boost.
- Fixes an issue in the development branch where the edit assignment links would not appear in the side bar for non-Boost themes.