### PR TITLE
Fix the inconsistency between install and upgrade scripts.

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -51,7 +51,7 @@
                 <FIELD NAME="erater_usage" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" ENUM="false" PREVIOUS="erater_grammar" NEXT="erater_mechanics"/>
                 <FIELD NAME="erater_mechanics" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" ENUM="false" PREVIOUS="erater_usage" NEXT="erater_style"/>
                 <FIELD NAME="erater_style" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" ENUM="false" PREVIOUS="erater_mechanics" NEXT="transmatch"/>
-                <FIELD NAME="transmatch" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" ENUM="false" PREVIOUS="erater_style" NEXT="needs_updating"/>
+                <FIELD NAME="transmatch" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" ENUM="false" PREVIOUS="erater_style" NEXT="needs_updating"/>
                 <FIELD NAME="needs_updating" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" PREVIOUS="transmatch" NEXT="institution_check"/>
                 <FIELD NAME="institution_check" TYPE="int" LENGTH="1" NOTNULL="false" UNSIGNED="false" DEFAULT="0" SEQUENCE="false" PREVIOUS="needs_updating" NEXT="migrated"/>
                 <FIELD NAME="migrated" TYPE="int" LENGTH="1" NOTNULL="false" UNSIGNED="false" DEFAULT="0" SEQUENCE="false" PREVIOUS="institution_check" />
@@ -128,7 +128,7 @@
                 <FIELD NAME="submission_nmlastname" TYPE="text" LENGTH="medium" NOTNULL="false" UNSIGNED="true" SEQUENCE="false" ENUM="false" PREVIOUS="submission_nmfirstname" NEXT="submission_unanon"/>
                 <FIELD NAME="submission_unanon" TYPE="int" LENGTH="1" NOTNULL="true" UNSIGNED="true" DEFAULT="0" SEQUENCE="false" ENUM="false" PREVIOUS="submission_nmlastname" NEXT="submission_unanonreason"/>
                 <FIELD NAME="submission_unanonreason" TYPE="text" LENGTH="medium" NOTNULL="false" UNSIGNED="true" SEQUENCE="false" ENUM="false" PREVIOUS="submission_unanon" NEXT="submission_transmatch"/>
-                <FIELD NAME="submission_transmatch" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" ENUM="false" PREVIOUS="submission_unanonreason" NEXT="submission_hash"/>
+                <FIELD NAME="submission_transmatch" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" UNSIGNED="true" SEQUENCE="false" ENUM="false" PREVIOUS="submission_unanonreason" NEXT="submission_hash"/>
                 <FIELD NAME="submission_hash" TYPE="char" LENGTH="100" NOTNULL="false" UNSIGNED="false" SEQUENCE="false" PREVIOUS="submission_transmatch"/>
             </FIELDS>
             <KEYS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -577,6 +577,46 @@ function xmldb_turnitintool_upgrade($oldversion) {
         }
     }
 
+    if ($result && $oldversion < 2020073000) {
+        if (is_callable(array($DB,'get_manager'))) {
+            $dbman = $DB->get_manager();
+            $table = new xmldb_table('turnitintool');
+
+            // The transmatch column should allow NULL.
+            $field = new xmldb_field('transmatch', XMLDB_TYPE_INTEGER, '10', true, false, false, 0, 'erater_style');
+            if ($dbman->field_exists($table, $field)) {
+                $dbman->change_field_notnull($table, $field);
+            }
+
+            // The needs_updating column should allow NULL and has a length of 10.
+            $field = new xmldb_field('needs_updating', XMLDB_TYPE_INTEGER, '10', true, false, false, 0, 'transmatch');
+            if ($dbman->field_exists($table, $field)) {
+                $dbman->change_field_notnull($table, $field);
+                $dbman->change_field_precision($table, $field);
+            }
+
+            // The institution_check column should allow NULL.
+            $field = new xmldb_field('institution_check', XMLDB_TYPE_INTEGER, '1', false, false, false, 0, 'needs_updating');
+            if ($dbman->field_exists($table, $field)) {
+                $dbman->change_field_notnull($table, $field);
+            }
+
+            // The migrated column should allow NULL.
+            $field = new xmldb_field('migrated', XMLDB_TYPE_INTEGER, '1', false, false, false, 0, 'institution_check');
+            if ($dbman->field_exists($table, $field)) {
+                $dbman->change_field_notnull($table, $field);
+            }
+
+            $table = new xmldb_table('turnitintool_submissions');
+
+            // The submission_transmatch column should allow NULL.
+            $field = new xmldb_field('submission_transmatch', XMLDB_TYPE_INTEGER, '10', true, false, false, 0, 'submission_unanonreason');
+            if ($dbman->field_exists($table, $field)) {
+                $dbman->change_field_notnull($table, $field);
+            }
+        }
+    }
+
     return $result;
 }
 

--- a/version.php
+++ b/version.php
@@ -8,7 +8,7 @@ if (!isset($plugin)) {
     $plugin = new StdClass();
 }
 
-$plugin->version  = 2018052201;  // The current module version (Date: YYYYMMDDXX)
+$plugin->version  = 2020073000;  // The current module version (Date: YYYYMMDDXX)
 $plugin->release   = "2.6+";
 $plugin->component = 'mod_turnitintool';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
This is a fix for #81 

While `needs_updating`, `institution_check` and `migrated` can be simply altered in `upgrade.php`, `transmatch` and `submission_transmatch` can't be smiply altered to be NOT NULL as there can be records with NULL values (in my case there are some records with NULL values).
 So I propose to let them be nullable.
